### PR TITLE
add atom/wrap-guide color, fix indent guide color

### DIFF
--- a/index.less
+++ b/index.less
@@ -3,6 +3,16 @@
   color: #c0c5ce;
 }
 
+.editor {
+  .indent-guide {
+    color: rgba(255, 255, 255, 0.1);
+  }
+
+  .wrap-guide {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+}
+
 .editor.is-focused .cursor {
   border-color: #c0c5ce;
 }


### PR DESCRIPTION
This PR adds support for the [atom/wrap-guide](https://github.com/atom/wrap-guide) package that's included in Atom by default. Also fixes the indent guide color to more closely match the original.
