### PR TITLE
Transparency for cursor line

### DIFF
--- a/index.less
+++ b/index.less
@@ -26,7 +26,7 @@ atom-text-editor.is-focused .selection .region,
 
 atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line,
 :host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
-  background-color: #343d46;
+  background-color: rgba(52, 61, 70, 0.5);
 }
 
 atom-text-editor .invisible-character,


### PR DESCRIPTION
When using a linter or anything else that uses in-line highlighting, the cursor line makes those highlights invisible until the cursor is moved to a different line.

With a little transparency those errors/infos from a highlighter are still visible, even when the cursor is in the affected line.